### PR TITLE
Update deprecated value in Cloudflare record resource

### DIFF
--- a/records/main.tf
+++ b/records/main.tf
@@ -7,7 +7,7 @@ resource "cloudflare_record" "this" {
   zone_id  = data.cloudflare_zone.this.id
   name     = each.value.name == "@" ? var.zone : each.value.name
   type     = each.value.type
-  value    = each.value.value
+  content  = each.value.value
   ttl      = each.value.proxied ? "1" : each.value.ttl
   priority = each.value.priority == "" ? null : each.value.priority
   proxied  = each.value.proxied


### PR DESCRIPTION
Change the deprecated `value` attribute to `content` in the Cloudflare record resource configuration.